### PR TITLE
Fix CI flake8 install

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install -e ".[dev]"
     - name: Lint with flake8
       run: |
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,15 @@ dev = [
     "ruff>=0.11.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "flake8>=7.1.2",
+    "mypy>=1.15.0",
+    "pytest>=8.3.5",
+    "pytest-cov>=6.0.0",
+    "ruff>=0.11.0",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"


### PR DESCRIPTION
## Summary
- ensure extras are quoted when installing in GitHub Actions

## Testing
- `pytest -q` *(fails: command not found)*