### PR TITLE
Fix pytest config and import path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-v --cov=. --cov-report=term-missing"
+addopts = "-v"
 markers = [
     "unit: marks tests as unit tests",
     "integration: marks tests as integration tests",

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -1,4 +1,10 @@
 import pytest
+import sys
+from pathlib import Path
+
+# Ensure the 'app' package is importable when tests are run directly
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 from app.schemas.chat import Message, ChatRequest, ChatResponse
 
 def test_message_schema():


### PR DESCRIPTION
## Summary
- remove coverage options from pytest settings
- ensure `app` package can be imported in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*