### PR TITLE
Fix imports in chat API

### DIFF
--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException
 from app.schemas.chat import ChatRequest, ChatResponse, Message
 from app.services.llm_service import llm_service
 import logging
-from typing import List
 
 router = APIRouter()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove unused imports from chat API
- ensure newline at end of file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aed35e05c832cb70bb121fb191b65