### PR TITLE
Add LangGraph agent integration

### DIFF
--- a/app/agents/langgraph_agent.py
+++ b/app/agents/langgraph_agent.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from langgraph.graph import StateGraph
+from langgraph.pregel import Node
+from app.schemas.chat import ChatRequest, ChatResponse
+from app.services.llm_service import llm_service
+
+class LangGraphAgent:
+    """LangGraph powered agent wrapping the existing LLMService."""
+
+    def __init__(self) -> None:
+        self._graph = StateGraph()
+        self._graph.add_node("llm_call", Node(self._llm_node))
+        self._graph.set_entry_point("llm_call")
+        self._compiled = self._graph.compile()
+
+    async def _llm_node(self, state: dict) -> dict:
+        request: ChatRequest = state["request"]
+        response = await llm_service.generate_response(request)
+        return {"response": response}
+
+    async def invoke(self, request: ChatRequest) -> ChatResponse:
+        result = await self._compiled.invoke({"request": request})
+        return result["response"]
+
+# Global instance for easy reuse
+langgraph_agent = LangGraphAgent()

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Depends
 from app.schemas.chat import ChatRequest, ChatResponse, Message
-from app.services.llm_service import llm_service
+from app.agents.langgraph_agent import langgraph_agent
 import logging
 from typing import List
 
@@ -19,7 +19,7 @@ async def chat(request: ChatRequest):
     - **stream**: (Optional) Whether to stream the response
     """
     try:
-        response = await llm_service.generate_response(request)
+        response = await langgraph_agent.invoke(request)
         return response
     except Exception as e:
         logger.error(f"Error in chat endpoint: {str(e)}")
@@ -55,7 +55,7 @@ async def chat_with_system(
             max_tokens=max_tokens
         )
         
-        response = await llm_service.generate_response(request)
+        response = await langgraph_agent.invoke(request)
         return response
     except Exception as e:
         logger.error(f"Error in chat_with_system endpoint: {str(e)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "google-generativeai>=0.5.4",
     "python-dotenv>=1.0.1",
     "uvicorn>=0.34.0",
+    "langchain>=0.1",
+    "langgraph>=0.0.35",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- introduce `LangGraphAgent` to wrap `LLMService`
- use the new agent in chat API
- declare LangGraph and LangChain dependencies

## Testing
- `pytest -q` *(fails: error: unrecognized arguments --cov=. --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_68691c1777e8832cadc1ddf8ae7d5fd8