### PR TITLE
Add AKS deployment docs and infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,50 @@ pytest
    docker run -p 8000:8000 --env-file .env llm-chat-app
    ```
 
+## Deployment to AKS with Kustomize
+
+Kubernetes manifests are provided in the `k8s/` directory. The `base` folder
+contains common resources and `overlays/production` contains production
+configuration such as replica count and image tag.
+
+Deploy the application with:
+
+```bash
+kubectl apply -k k8s/overlays/production
+```
+
+Create a `llm-chat-app-secrets` secret in the namespace with your API keys
+before applying the manifests.
+
+## Provisioning AKS with Pulumi
+
+The `infra/pulumi` folder holds a Pulumi program for creating the AKS cluster.
+Install the requirements and run `pulumi up`:
+
+```bash
+cd infra/pulumi
+pip install -r requirements.txt
+pulumi up
+```
+
+The program provisions a resource group and an AKS cluster and exports the
+kubeconfig for cluster access.
+
+## GitOps with Argo CD
+
+Once the cluster is running and Argo CD is installed, create an application that
+points to the Kustomize overlay:
+
+```bash
+argocd app create llm-chat-app \
+  --repo https://github.com/yourusername/llm_chat_app.git \
+  --path k8s/overlays/production \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace default
+
+argocd app sync llm-chat-app
+```
+
 ## Contributing
 
 1. Fork the repository

--- a/infra/pulumi/Pulumi.yaml
+++ b/infra/pulumi/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: llm-chat-app-aks
+runtime: python

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -1,0 +1,35 @@
+import pulumi
+from pulumi_azure_native import resources, containerservice
+
+# Configurable variables
+config = pulumi.Config()
+resource_group_name = config.get('resourceGroupName') or 'llm-chat-rg'
+location = config.get('location') or 'eastus'
+cluster_name = config.get('clusterName') or 'llm-chat-aks'
+
+# Resource group
+resource_group = resources.ResourceGroup('resource-group',
+    resource_group_name=resource_group_name,
+    location=location)
+
+# AKS cluster
+aks_cluster = containerservice.ManagedCluster(
+    'aks-cluster',
+    resource_group_name=resource_group.name,
+    location=resource_group.location,
+    dns_prefix='llm-chat',
+    agent_pool_profiles=[containerservice.ManagedClusterAgentPoolProfileArgs(
+        name='agentpool',
+        mode='System',
+        count=3,
+        vm_size='Standard_DS2_v2',
+    )],
+    identity=containerservice.ManagedClusterIdentityArgs(
+        type='SystemAssigned'
+    ),
+)
+
+pulumi.export('kubeconfig', containerservice.list_managed_cluster_user_credentials_output(
+    resource_group_name=resource_group.name,
+    resource_name=aks_cluster.name
+).kubeconfigs[0].value.apply(lambda enc: enc.decode('utf-8')))

--- a/infra/pulumi/requirements.txt
+++ b/infra/pulumi/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=3.109.0
+pulumi-azure-native>=2.40.0

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-chat-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-chat-app
+  template:
+    metadata:
+      labels:
+        app: llm-chat-app
+    spec:
+      containers:
+        - name: llm-chat-app
+          image: ghcr.io/yourusername/llm_chat_app:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: LLM_PROVIDER
+              value: "openai"
+            - name: LLM_MODEL
+              value: "gpt-4"
+          envFrom:
+            - secretRef:
+                name: llm-chat-app-secrets
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/service.yaml
+++ b/k8s/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-chat-app
+spec:
+  selector:
+    app: llm-chat-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP

--- a/k8s/overlays/production/deployment-patch.yaml
+++ b/k8s/overlays/production/deployment-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-chat-app
+spec:
+  replicas: 3

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/yourusername/llm_chat_app
+    newTag: latest
+patchesStrategicMerge:
+  - deployment-patch.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,7 @@ markers = [
     "integration: marks tests as integration tests",
     "slow: marks tests as slow running",
 ]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]


### PR DESCRIPTION
## Summary
- add Kubernetes manifests with Kustomize overlays
- provide Pulumi program to create the AKS cluster
- document AKS, Pulumi and Argo CD setup in README
- tweak packaging configuration for new directories

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c107feef0832c979370b2062458ad