### PR TITLE
Refactor backend for object oriented style

### DIFF
--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,13 +1,67 @@
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 import json
+from dataclasses import dataclass, field
+import logging
+
 from app.schemas.chat import ChatRequest, ChatResponse, Message
 from app.agents.langgraph_agent import langgraph_agent
 from app.services.llm_service import llm_service
-import logging
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatController:
+    """Controller handling chat related operations."""
+
+    agent: any = field(default_factory=lambda: langgraph_agent)
+    service: any = field(default_factory=lambda: llm_service)
+
+    async def generate(self, request: ChatRequest) -> ChatResponse:
+        """Generate a chat response using the configured agent."""
+        return await self.agent.invoke(request)
+
+    async def generate_with_system(
+        self,
+        system_message: str,
+        user_message: str,
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+    ) -> ChatResponse:
+        messages = [
+            Message(role="system", content=system_message),
+            Message(role="user", content=user_message),
+        ]
+
+        request = ChatRequest(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return await self.agent.invoke(request)
+
+    async def stream(self, request: ChatRequest):
+        """Stream a response from the LLM service."""
+
+        async def event_generator():
+            yield (
+                "data: "
+                + json.dumps({"choices": [{"delta": {"role": "assistant"}}]})
+                + "\n\n"
+            )
+            async for chunk in self.service.stream_response(request):
+                data = json.dumps({"choices": [{"delta": {"content": chunk}}]})
+                yield f"data: {data}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+controller = ChatController()
 
 
 @router.post("/chat", response_model=ChatResponse, summary="Generate a chat response")
@@ -22,7 +76,7 @@ async def chat(request: ChatRequest):
     - **stream**: (Optional) Whether to stream the response
     """
     try:
-        response = await langgraph_agent.invoke(request)
+        response = await controller.generate(request)
         return response
     except Exception as e:
         logger.error(f"Error in chat endpoint: {str(e)}")
@@ -39,9 +93,9 @@ async def chat(request: ChatRequest):
 async def chat_with_system(
     system_message: str,
     user_message: str,
-    model: str = None,
+    model: str | None = None,
     temperature: float = 0.7,
-    max_tokens: int = None,
+    max_tokens: int | None = None,
 ):
     """
     Generate a response with a system message prepended to the conversation.
@@ -53,19 +107,13 @@ async def chat_with_system(
     - **max_tokens**: (Optional) The maximum number of tokens to generate
     """
     try:
-        messages = [
-            Message(role="system", content=system_message),
-            Message(role="user", content=user_message),
-        ]
-
-        request = ChatRequest(
-            messages=messages,
+        response = await controller.generate_with_system(
+            system_message,
+            user_message,
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
         )
-
-        response = await langgraph_agent.invoke(request)
         return response
     except Exception as e:
         logger.error(f"Error in chat_with_system endpoint: {str(e)}")
@@ -78,16 +126,10 @@ async def chat_with_system(
 async def chat_stream(request: ChatRequest):
     """Stream tokens from the LLM using OpenAI-compatible SSE."""
 
-    async def event_generator():
-        # send initial role event as OpenAI does
-        yield (
-            "data: "
-            + json.dumps({"choices": [{"delta": {"role": "assistant"}}]})
-            + "\n\n"
+    try:
+        return await controller.stream(request)
+    except Exception as e:
+        logger.error(f"Error in chat_stream endpoint: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error generating response: {str(e)}"
         )
-        async for chunk in llm_service.stream_response(request):
-            data = json.dumps({"choices": [{"delta": {"content": chunk}}]})
-            yield f"data: {data}\n\n"
-        yield "data: [DONE]\n\n"
-
-    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,18 +1,22 @@
 import openai
-from typing import List, Dict, Any, AsyncGenerator
+import logging
+from dataclasses import dataclass, field
+from typing import List, Dict, AsyncGenerator
+
 from app.core.config import settings
 from app.schemas.chat import Message, ChatRequest, ChatResponse
-import logging
 
 logger = logging.getLogger(__name__)
 
+@dataclass
 class LLMService:
     """Service for interacting with various LLM APIs with a unified interface."""
 
-    def __init__(self) -> None:
-        """Initialize the LLM service based on the configured provider."""
-        self.provider = settings.LLM_PROVIDER.lower()
-        self.model = settings.LLM_MODEL
+    provider: str = field(default_factory=lambda: settings.LLM_PROVIDER.lower())
+    model: str = field(default_factory=lambda: settings.LLM_MODEL)
+
+    def __post_init__(self) -> None:
+        """Initialize the LLM client based on the configured provider."""
 
         if self.provider == "openai":
             self.client = openai.OpenAI(

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
-from app.main import app
+from app.main import app as application
 
 if __name__ == "__main__":
     import uvicorn
     from app.core.config import settings
     
     uvicorn.run(
-        "app.main:app",
+        application,
         host=settings.HOST,
         port=settings.PORT,
         reload=settings.DEBUG,

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -11,8 +11,8 @@ class DummyAgent:
 agent_stub.langgraph_agent = DummyAgent()
 sys.modules.setdefault("app.agents.langgraph_agent", agent_stub)
 
-from app.main import app
-from app.schemas.chat import Message, ChatResponse
+from app.main import app  # noqa: E402
+from app.schemas.chat import Message, ChatResponse  # noqa: E402
 
 client = TestClient(app)
 

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -1,4 +1,3 @@
-import pytest
 from app.schemas.chat import Message, ChatRequest, ChatResponse
 
 def test_message_schema():


### PR DESCRIPTION
## Summary
- create `ChatApp` class to encapsulate FastAPI setup
- add `ChatController` dataclass and update endpoints
- convert `LLMService` to a dataclass
- address lint issues

## Testing
- `ruff check .`
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880a5a0ec84832c800253d088d2946a