### PR TITLE
Add Azure OpenAI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # LLM Chat App
 
-A modern chat application powered by multiple providers (OpenAI, Anthropic, and Google's Gemini), allowing users to interact with various LLM models through a clean and intuitive interface.
+A modern chat application powered by multiple providers (Azure OpenAI, OpenAI, Anthropic, and Google's Gemini), allowing users to interact with various LLM models through a clean and intuitive interface.
 
 ## Features
 
-- Chat with OpenAI, Anthropic, or Gemini models using a unified API
+- Chat with Azure OpenAI, OpenAI, Anthropic, or Gemini models using a unified API
 - Adjustable parameters (temperature, max tokens)
 - Code block rendering
 - Dark mode support
@@ -16,7 +16,7 @@ A modern chat application powered by multiple providers (OpenAI, Anthropic, and 
 
 - **Backend**: FastAPI, Python 3.12.2
 - **Frontend**: HTML, CSS, JavaScript
-- **LLM Integration**: OpenAI-compatible providers (OpenAI, Anthropic, Gemini)
+- **LLM Integration**: OpenAI-compatible providers (Azure OpenAI, OpenAI, Anthropic, Gemini)
 - **Dependency Management**: uv
 - **Containerization**: Docker
 - **Deployment**: Azure Kubernetes Service (AKS)
@@ -45,14 +45,19 @@ A modern chat application powered by multiple providers (OpenAI, Anthropic, and 
    pip install -e .
    ```
 
-3. Create a `.env` file in the root directory with your LLM provider settings:
+3. Create a `.env` file in the root directory with your LLM provider settings.
+   Example for Azure OpenAI:
    ```
    LLM_API_KEY=your_api_key_here
-    LLM_API_ENDPOINT=https://api.openai.com/v1
-    LLM_MODEL=gpt-4
-    LLM_PROVIDER=openai
+   LLM_PROVIDER=azure
+   LLM_API_ENDPOINT=https://your-resource.openai.azure.com
+   LLM_DEPLOYMENT=your-deployment-name
+   LLM_API_VERSION=2024-02-15-preview
+   LLM_MODEL=gpt-4
    SECRET_KEY=your_secret_key_here
    ```
+   For OpenAI or Anthropic, set `LLM_PROVIDER` to `openai` or `anthropic` and
+   adjust the endpoint and model accordingly.
 
 4. Run the application:
    ```bash
@@ -169,7 +174,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Acknowledgements
 
-- OpenAI, Anthropic and Google for providing the LLM capabilities
+- OpenAI, Azure OpenAI, Anthropic and Google for providing the LLM capabilities
 - FastAPI for the efficient API framework
 - The open-source community for various libraries and tools used in this project
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
     LLM_API_ENDPOINT: str = os.getenv("LLM_API_ENDPOINT", "https://api.openai.com/v1")
     LLM_MODEL: str = os.getenv("LLM_MODEL", "gpt-4")
     LLM_PROVIDER: str = os.getenv("LLM_PROVIDER", "openai")
+    LLM_API_VERSION: Optional[str] = os.getenv("LLM_API_VERSION")
+    LLM_DEPLOYMENT: Optional[str] = os.getenv("LLM_DEPLOYMENT")
     
     # Application Settings
     APP_ENV: str = os.getenv("APP_ENV", "development")

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # Create the FastAPI application
 app = FastAPI(
     title="LLM Chat App",
-    description="A chat application powered by Azure OpenAI",
+    description="A chat application powered by OpenAI, Anthropic, and Gemini",
     version="0.1.0",
 )
 

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -19,6 +19,13 @@ class LLMService:
                 api_key=settings.LLM_API_KEY,
                 base_url=settings.LLM_API_ENDPOINT,
             )
+        elif self.provider == "azure":
+            self.client = openai.AzureOpenAI(
+                api_key=settings.LLM_API_KEY,
+                azure_endpoint=settings.LLM_API_ENDPOINT,
+                azure_deployment=settings.LLM_DEPLOYMENT,
+                api_version=settings.LLM_API_VERSION,
+            )
         elif self.provider == "anthropic":
             try:
                 import anthropic

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -131,7 +131,7 @@
     <div class="chat-container">
         <div class="chat-header">
             <h1>LLM Chat App</h1>
-            <p>Powered by Azure OpenAI</p>
+            <p>Powered by your favorite LLM provider</p>
         </div>
         
         <div class="chat-messages" id="chatMessages">


### PR DESCRIPTION
## Summary
- support Azure OpenAI via `AzureOpenAI` client
- expose `LLM_API_VERSION` and `LLM_DEPLOYMENT` settings
- generalize FastAPI description and homepage banner
- document provider configuration including Azure example

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a6e91fa8832c91c116ed317def70