### PR TITLE
Refactor ChatApp initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,15 +7,13 @@ from fastapi.templating import Jinja2Templates
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 import uvicorn
-from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
-@dataclass
 class ChatApp:
     """Encapsulates FastAPI application setup."""
 
-    def __post_init__(self) -> None:
+    def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
         logging.basicConfig(
             level=getattr(logging, settings.LOG_LEVEL),


### PR DESCRIPTION
## Summary
- simplify FastAPI setup
- initialize middlewares and routes in `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b77eebab8832c8abed4845d4f79fd