### PR TITLE
feat: Add Ollama support for local LLM models

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,7 +14,10 @@ class Settings(BaseSettings):
     LLM_API_KEY: str = Field(default="", description="API key for LLM provider")
     LLM_API_ENDPOINT: str = Field(default="https://api.openai.com/v1", description="LLM API endpoint")
     LLM_MODEL: str = Field(default="gpt-4", description="Default LLM model")
-    LLM_PROVIDER: str = Field(default="openai", description="LLM provider (openai, anthropic, gemini)")
+    LLM_PROVIDER: str = Field(default="openai", description="LLM provider (openai, anthropic, gemini, ollama)")
+    
+    # Ollama Configuration
+    OLLAMA_BASE_URL: str = Field(default="http://localhost:11434", description="Ollama API base URL")
     
     # Application Settings
     APP_ENV: str = Field(default="development", description="Application environment")
@@ -38,7 +41,7 @@ class Settings(BaseSettings):
     
     @validator('LLM_PROVIDER')
     def validate_provider(cls, v):
-        allowed_providers = ['openai', 'anthropic', 'gemini']
+        allowed_providers = ['openai', 'anthropic', 'gemini', 'ollama']
         if v.lower() not in allowed_providers:
             raise ValueError(f'Provider must be one of: {allowed_providers}')
         return v.lower()
@@ -51,7 +54,11 @@ class Settings(BaseSettings):
         return v.upper()
     
     @validator('LLM_API_KEY')
-    def validate_api_key(cls, v):
+    def validate_api_key(cls, v, values):
+        # Ollama doesn't require an API key
+        provider = values.get('LLM_PROVIDER', '').lower()
+        if provider == 'ollama':
+            return ""  # No API key needed for Ollama
         # Only validate if API key is provided (allow empty for development)
         if v and len(v.strip()) < 10:
             raise ValueError('LLM_API_KEY must be at least 10 characters long when provided')

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -15,6 +15,7 @@ class ChatRequest(BaseModel):
     temperature: Optional[float] = Field(0.7, description="The temperature to use for the response", ge=0.0, le=2.0)
     max_tokens: Optional[int] = Field(None, description="The maximum number of tokens to generate")
     stream: Optional[bool] = Field(False, description="Whether to stream the response")
+    provider: Optional[str] = Field(None, description="Override the default provider (e.g., 'ollama' for local models)")
 
 class ChatResponse(BaseModel):
     """Schema for a chat response."""

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -46,6 +46,15 @@ class LLMService:
 
                 genai.configure(api_key=settings.LLM_API_KEY)
                 self.client = genai.GenerativeModel(self.model)
+            elif self.provider == "ollama":
+                try:
+                    import ollama
+                except ImportError as e:
+                    raise ImportError("ollama package is required for Ollama provider") from e
+                
+                self.ollama_base_url = settings.OLLAMA_BASE_URL
+                self.client = None  # Ollama uses module-level functions
+                logger.info(f"Configured Ollama provider with base URL: {self.ollama_base_url}")
             else:
                 raise ValueError(f"Unsupported LLM provider: {self.provider}")
                 
@@ -143,6 +152,50 @@ class LLMService:
             logger.error(f"Unexpected Anthropic error: {str(e)}")
             raise
 
+    async def _handle_ollama_response(self, request: ChatRequest) -> ChatResponse:
+        """Handle Ollama API response."""
+        try:
+            import ollama
+            
+            model = request.model or self.model
+            formatted_messages = self.format_messages(request.messages)
+            
+            # Set the host if different from default
+            if self.ollama_base_url != "http://localhost:11434":
+                ollama_client = ollama.AsyncClient(host=self.ollama_base_url)
+            else:
+                ollama_client = ollama.AsyncClient()
+            
+            # Call Ollama API
+            response = await ollama_client.chat(
+                model=model,
+                messages=formatted_messages,
+                options={
+                    "temperature": request.temperature,
+                    "num_predict": request.max_tokens or -1,
+                },
+                stream=False
+            )
+            
+            # Extract content from response
+            content = response.get('message', {}).get('content', '')
+            
+            # Create usage info if available
+            usage = {}
+            if 'eval_count' in response:
+                usage['completion_tokens'] = response['eval_count']
+            if 'prompt_eval_count' in response:
+                usage['prompt_tokens'] = response['prompt_eval_count']
+            if usage:
+                usage['total_tokens'] = usage.get('prompt_tokens', 0) + usage.get('completion_tokens', 0)
+            
+            assistant_message = Message(role="assistant", content=content)
+            return ChatResponse(message=assistant_message, model=model, usage=usage)
+            
+        except Exception as e:
+            logger.error(f"Ollama API error: {str(e)}")
+            raise Exception(f"Ollama API error: {str(e)}")
+
     async def _handle_gemini_response(self, request: ChatRequest) -> ChatResponse:
         """Handle Gemini API response."""
         try:
@@ -180,16 +233,20 @@ class LLMService:
     async def generate_response(self, request: ChatRequest) -> ChatResponse:
         """Generate a response from the LLM with proper error handling."""
         try:
-            logger.info(f"Generating response using {self.provider} provider")
+            # Use provider from request if specified, otherwise use default
+            provider = request.provider or self.provider
+            logger.info(f"Generating response using {provider} provider")
             
-            if self.provider == "openai":
+            if provider == "openai":
                 return await self._handle_openai_response(request)
-            elif self.provider == "anthropic":
+            elif provider == "anthropic":
                 return await self._handle_anthropic_response(request)
-            elif self.provider == "gemini":
+            elif provider == "gemini":
                 return await self._handle_gemini_response(request)
+            elif provider == "ollama":
+                return await self._handle_ollama_response(request)
             else:
-                raise ValueError(f"Unsupported provider: {self.provider}")
+                raise ValueError(f"Unsupported provider: {provider}")
                 
         except Exception as e:
             logger.error(f"Error generating response: {str(e)}")
@@ -198,10 +255,12 @@ class LLMService:
     async def stream_response(self, request: ChatRequest) -> AsyncGenerator[str, None]:
         """Stream a response from the LLM as it is generated."""
         try:
+            # Use provider from request if specified, otherwise use default
+            provider = request.provider or self.provider
             model = request.model or self.model
             formatted_messages = self.format_messages(request.messages)
 
-            if self.provider == "openai":
+            if provider == "openai":
                 stream = await self.client.chat.completions.create(
                     model=model,
                     messages=formatted_messages,
@@ -214,7 +273,7 @@ class LLMService:
                     if delta:
                         yield delta
                         
-            elif self.provider == "anthropic":
+            elif provider == "anthropic":
                 import anthropic
                 response = await self.client.messages.create(
                     model=model,
@@ -226,6 +285,33 @@ class LLMService:
                 async for block in response:
                     if hasattr(block, "text") and block.text:
                         yield block.text
+                        
+            elif provider == "ollama":
+                import ollama
+                
+                model = request.model or self.model
+                formatted_messages = self.format_messages(request.messages)
+                
+                # Set the host if different from default
+                if self.ollama_base_url != "http://localhost:11434":
+                    ollama_client = ollama.AsyncClient(host=self.ollama_base_url)
+                else:
+                    ollama_client = ollama.AsyncClient()
+                
+                # Stream from Ollama
+                stream = await ollama_client.chat(
+                    model=model,
+                    messages=formatted_messages,
+                    options={
+                        "temperature": request.temperature,
+                        "num_predict": request.max_tokens or -1,
+                    },
+                    stream=True
+                )
+                
+                async for chunk in stream:
+                    if 'message' in chunk and 'content' in chunk['message']:
+                        yield chunk['message']['content']
                         
             else:  # gemini
                 conversation = "\n".join(f"{m.role}: {m.content}" for m in request.messages)

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -47,7 +47,15 @@ document.addEventListener('DOMContentLoaded', function() {
         const loadingDiv = showLoading();
         
         // Get settings
-        const model = modelSelect.value;
+        let model = modelSelect.value;
+        let provider = null;
+        
+        // Check if it's an Ollama model
+        if (model && model.startsWith('ollama:')) {
+            provider = 'ollama';
+            model = model.replace('ollama:', '');  // Remove prefix
+        }
+        
         const temperature = parseFloat(temperatureRange.value);
         const maxTokens = maxTokensInput.value ? parseInt(maxTokensInput.value) : null;
         
@@ -64,7 +72,8 @@ document.addEventListener('DOMContentLoaded', function() {
             model: model || null,
             temperature: temperature,
             max_tokens: maxTokens,
-            stream: true
+            stream: true,
+            provider: provider  // Add provider if Ollama
         };
 
         // Send request to API with streaming response

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -151,9 +151,18 @@
                 <div class="col-md-4">
                     <label for="modelSelect" class="form-label">Model</label>
                     <select id="modelSelect" class="form-select">
-                        <option value="">Default (gpt-4)</option>
-                        <option value="gpt-4">GPT-4</option>
-                        <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
+                        <optgroup label="Azure OpenAI (Cloud)">
+                            <option value="">Default (gpt-4)</option>
+                            <option value="gpt-4">GPT-4</option>
+                            <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
+                        </optgroup>
+                        <optgroup label="Ollama (Local)">
+                            <option value="ollama:gpt-oss:20b">GPT-OSS 20B 🏠</option>
+                            <option value="ollama:llama3.1:70b">Llama 3.1 70B 🏠</option>
+                            <option value="ollama:mixtral:8x7b">Mixtral 8x7B 🏠</option>
+                            <option value="ollama:deepseek-coder:6.7b">DeepSeek Coder 🏠</option>
+                            <option value="ollama:llama3.2:3b">Llama 3.2 3B (Fast) 🏠</option>
+                        </optgroup>
                     </select>
                 </div>
                 <div class="col-md-4">

--- a/docs/OLLAMA_SETUP.md
+++ b/docs/OLLAMA_SETUP.md
@@ -1,0 +1,180 @@
+# Using Ollama with LLM Chat App
+
+This guide explains how to use local models through Ollama with the LLM Chat App, including GPT-OSS models.
+
+## Prerequisites
+
+1. **Install Ollama**
+   ```bash
+   # macOS
+   brew install ollama
+   
+   # Linux
+   curl -fsSL https://ollama.ai/install.sh | sh
+   ```
+
+2. **Start Ollama Service**
+   ```bash
+   ollama serve
+   ```
+
+3. **Download Models**
+   ```bash
+   # GPT-OSS 20B (OpenAI's open model)
+   ollama pull gpt-oss:20b
+   
+   # Other recommended models
+   ollama pull llama3.1:70b        # Meta's latest, very capable
+   ollama pull mixtral:8x7b        # Good for reasoning
+   ollama pull deepseek-coder:6.7b # Excellent for code
+   ollama pull llama3.2:3b         # Fast, lightweight
+   ```
+
+## Configuration
+
+### Option 1: Use Ollama as Default Provider
+
+1. Copy the example environment file:
+   ```bash
+   cp .env.ollama.example .env
+   ```
+
+2. The key settings are:
+   ```env
+   LLM_PROVIDER=ollama
+   OLLAMA_BASE_URL=http://localhost:11434
+   LLM_MODEL=gpt-oss:20b
+   ```
+
+### Option 2: Hybrid Setup (Cloud + Local)
+
+Keep your existing Azure/OpenAI configuration and select Ollama models from the UI:
+
+1. Keep your current `.env` with Azure/OpenAI settings
+2. Add Ollama configuration:
+   ```env
+   OLLAMA_BASE_URL=http://localhost:11434
+   ```
+3. Select Ollama models from the dropdown in the UI (marked with 🏠)
+
+## Usage
+
+### From the Web Interface
+
+1. Start the application:
+   ```bash
+   python main.py
+   ```
+
+2. Open http://localhost:8000
+
+3. In the Model dropdown, select any model marked with 🏠:
+   - **GPT-OSS 20B 🏠** - OpenAI's open model
+   - **Llama 3.1 70B 🏠** - Meta's latest
+   - **Mixtral 8x7B 🏠** - MoE architecture
+   - **DeepSeek Coder 🏠** - For programming
+   - **Llama 3.2 3B (Fast) 🏠** - Quick responses
+
+### From Python Code
+
+```python
+from app.schemas.chat import ChatRequest, Message
+from app.services.llm_service import LLMService
+
+# Create a request specifying Ollama
+request = ChatRequest(
+    messages=[
+        Message(role="user", content="Hello, GPT-OSS!")
+    ],
+    model="gpt-oss:20b",
+    provider="ollama"  # Explicitly use Ollama
+)
+
+# Generate response
+service = LLMService()
+response = await service.generate_response(request)
+print(response.message.content)
+```
+
+## Testing
+
+Run the test script to verify your setup:
+
+```bash
+python test_ollama.py
+```
+
+## Performance Tips
+
+### For M4 Pro (48GB RAM)
+
+**Recommended Models by Use Case:**
+- **General Chat**: `gpt-oss:20b` or `llama3.1:70b-q4`
+- **Fast Responses**: `llama3.2:3b` or `phi3:mini`
+- **Code Generation**: `deepseek-coder:6.7b` or `codellama:13b`
+- **Long Context**: `yarn-mistral:7b-128k`
+
+**Memory Usage:**
+- GPT-OSS 20B: ~12-15GB RAM
+- Llama 3.1 70B (4-bit): ~35-40GB RAM
+- Mixtral 8x7B: ~25-30GB RAM
+- Small models (3-7B): 4-8GB RAM
+
+### Optimization
+
+1. **Keep Models Loaded**: Ollama keeps models in memory for 5 minutes by default
+   ```bash
+   # Keep a model loaded longer
+   ollama run gpt-oss:20b --keepalive 30m
+   ```
+
+2. **Use Appropriate Quantization**: 
+   - Q4 models offer best balance of quality/speed
+   - Q8 for maximum quality (uses more RAM)
+   - Q2-Q3 for speed (lower quality)
+
+3. **Monitor Performance**:
+   ```bash
+   # Check loaded models
+   ollama ps
+   
+   # See model details
+   ollama show gpt-oss:20b
+   ```
+
+## Troubleshooting
+
+### "Connection refused" error
+- Ensure Ollama is running: `ollama serve`
+- Check if port 11434 is available: `lsof -i :11434`
+
+### "Model not found" error
+- Download the model first: `ollama pull model-name`
+- Check available models: `ollama list`
+
+### Slow responses
+- Check RAM usage: `top` or Activity Monitor
+- Use a smaller/quantized model
+- Close other applications to free RAM
+
+### Application doesn't show Ollama models
+- Restart the application after installing `ollama` package:
+  ```bash
+  pip install -e ".[dev]"  # Reinstall dependencies
+  python main.py
+  ```
+
+## Benefits of Local Models
+
+✅ **Privacy**: Your data never leaves your machine
+✅ **No API Costs**: Free after initial download
+✅ **Offline Access**: Works without internet
+✅ **Low Latency**: No network roundtrip
+✅ **Customization**: Fine-tune models for your needs
+
+## Next Steps
+
+1. Try different models to find what works best for your use case
+2. Experiment with temperature and max_tokens settings
+3. Consider fine-tuning models for specialized tasks
+4. Set up model switching for different types of queries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "langgraph>=0.5.1",
     "aiohttp>=3.9.0",
     "sqlalchemy>=2.0.41",
+    "ollama>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/test_ollama.py
+++ b/test_ollama.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Test script for Ollama integration with the chat app."""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from app.schemas.chat import ChatRequest, Message
+from app.services.llm_service import LLMService
+
+
+async def test_ollama_chat():
+    """Test Ollama chat completion."""
+    print("Testing Ollama integration...")
+    
+    # Create a request with Ollama provider
+    request = ChatRequest(
+        messages=[
+            Message(role="system", content="You are a helpful assistant."),
+            Message(role="user", content="Say 'Hello from Ollama!' and nothing else.")
+        ],
+        model="llama3.2:3b",  # Use a small model for testing
+        temperature=0.7,
+        provider="ollama"  # Explicitly use Ollama
+    )
+    
+    try:
+        # Create service instance (will use default provider from settings)
+        service = LLMService()
+        
+        # Test non-streaming response
+        print("\n1. Testing non-streaming response...")
+        response = await service.generate_response(request)
+        print(f"Response: {response.message.content}")
+        print(f"Model used: {response.model}")
+        if response.usage:
+            print(f"Tokens: {response.usage}")
+        
+        # Test streaming response
+        print("\n2. Testing streaming response...")
+        request.stream = True
+        print("Streaming: ", end="", flush=True)
+        async for chunk in service.stream_response(request):
+            print(chunk, end="", flush=True)
+        print("\n")
+        
+        print("\n✅ Ollama integration test successful!")
+        
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        print("\nMake sure:")
+        print("1. Ollama is running (ollama serve)")
+        print("2. You have a model installed (ollama pull llama3.2:3b)")
+        return False
+    
+    return True
+
+
+async def test_model_switching():
+    """Test switching between cloud and local models."""
+    print("\n3. Testing model switching...")
+    
+    service = LLMService()
+    
+    # Test with default provider (should be OpenAI from config)
+    request1 = ChatRequest(
+        messages=[Message(role="user", content="Say 'Hello from cloud!'")],
+        model="gpt-3.5-turbo"
+    )
+    
+    # Test with Ollama override
+    request2 = ChatRequest(
+        messages=[Message(role="user", content="Say 'Hello from local!'")],
+        model="llama3.2:3b",
+        provider="ollama"
+    )
+    
+    try:
+        # Only test if both are available
+        print("Testing cloud model...")
+        # This might fail if no API key is set
+        try:
+            response1 = await service.generate_response(request1)
+            print(f"Cloud response: {response1.message.content[:50]}...")
+        except Exception as e:
+            print(f"Cloud model not available: {e}")
+        
+        print("Testing local model...")
+        response2 = await service.generate_response(request2)
+        print(f"Local response: {response2.message.content[:50]}...")
+        
+        print("\n✅ Model switching test successful!")
+        
+    except Exception as e:
+        print(f"\n❌ Error in model switching: {e}")
+        return False
+    
+    return True
+
+
+async def main():
+    """Run all tests."""
+    print("=" * 60)
+    print("OLLAMA INTEGRATION TEST SUITE")
+    print("=" * 60)
+    
+    # Test basic Ollama functionality
+    success = await test_ollama_chat()
+    
+    if success:
+        # Test model switching
+        await test_model_switching()
+    
+    print("\n" + "=" * 60)
+    print("TEST COMPLETE")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 🚀 Feature: Ollama Integration for Local LLM Models

This PR adds support for running local LLM models through Ollama, enabling privacy-focused, cost-effective AI capabilities.

## ✨ What's New

### Core Features
- **New Provider**: Added `ollama` as a fourth LLM provider alongside OpenAI, Anthropic, and Gemini
- **Local Model Support**: Run GPT-OSS-20B, Llama 3.1, Mixtral, and other open-source models locally
- **Hybrid Architecture**: Seamlessly switch between cloud and local models per request
- **Full Async Support**: Implemented async handlers for both streaming and non-streaming responses

### Models Supported
- 🏠 **GPT-OSS-20B** - OpenAI's new open-source model
- 🏠 **Llama 3.1 70B** - Meta's most capable model  
- 🏠 **Mixtral 8x7B** - Efficient MoE architecture
- 🏠 **DeepSeek Coder** - Specialized for code generation
- 🏠 **Llama 3.2 3B** - Fast, lightweight option

### Frontend Updates
- Grouped model selection (Cloud vs Local)
- Visual indicators (🏠) for local models
- Automatic provider detection based on model selection

## 🔧 Technical Details

### Configuration
- Added `OLLAMA_BASE_URL` setting (default: `http://localhost:11434`)
- Updated provider validation to include `ollama`
- Made API keys optional for Ollama provider

### Implementation
- New `_handle_ollama_response()` method in LLMService
- Provider override support in ChatRequest schema
- Smart routing in frontend JavaScript

## 📚 Documentation
- Comprehensive setup guide in `docs/OLLAMA_SETUP.md`
- Test script `test_ollama.py` for validation
- Configuration examples included

## 🧪 Testing
```bash
# Install dependencies
pip install -e ".[dev]"

# Start Ollama
ollama serve

# Download a model
ollama pull llama3.2:3b

# Run tests
python test_ollama.py
```

## ✅ Benefits
- **Privacy**: Data never leaves your machine
- **Cost**: No API costs after model download
- **Speed**: No network latency
- **Flexibility**: Use cloud or local models as needed

## 🔄 Backward Compatibility
- Fully backward compatible with existing setup
- No breaking changes
- Can run in cloud-only, local-only, or hybrid mode

Closes #31