### PR TITLE
feat: Add Exa web search integration for Ollama models

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -44,6 +44,10 @@ class Settings(BaseSettings):
     HTTP_MAX_KEEPALIVE: int = Field(default=20, description="Maximum keep-alive connections", ge=1, le=100)
     HTTP_KEEPALIVE_EXPIRY: int = Field(default=30, description="Keep-alive connection expiry in seconds", ge=5, le=300)
     HTTP_CONNECTION_TIMEOUT: int = Field(default=10, description="Connection timeout in seconds", ge=1, le=60)
+    
+    # Exa Search Configuration
+    EXA_API_KEY: Optional[str] = Field(default=None, description="Exa API key for web search")
+    EXA_SEARCH_ENABLED: bool = Field(default=False, description="Enable Exa web search for Ollama models")
     @validator('LLM_PROVIDER')
     def validate_provider(cls, v):
         allowed_providers = ['openai', 'anthropic', 'gemini', 'ollama']
@@ -63,7 +67,7 @@ class Settings(BaseSettings):
         # Ollama doesn't require an API key
         provider = values.get('LLM_PROVIDER', '').lower()
         if provider == 'ollama':
-            return ""  # No API key needed for Ollama
+            return v.strip() if v else ""  # No API key needed for Ollama
         # Only validate if API key is provided (allow empty for development)
         if v and len(v.strip()) < 10:
             raise ValueError('LLM_API_KEY must be at least 10 characters long when provided')

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -12,10 +12,11 @@ class ChatRequest(BaseModel):
     """Schema for a chat request."""
     messages: List[Message] = Field(..., description="The list of messages in the conversation")
     model: Optional[str] = Field(None, description="The model to use for the response")
+    provider: Optional[str] = Field(None, description="The provider to use (openai, anthropic, gemini, ollama)")
     temperature: Optional[float] = Field(0.7, description="The temperature to use for the response", ge=0.0, le=2.0)
     max_tokens: Optional[int] = Field(None, description="The maximum number of tokens to generate")
     stream: Optional[bool] = Field(False, description="Whether to stream the response")
-    provider: Optional[str] = Field(None, description="Override the default provider (e.g., 'ollama' for local models)")
+    enable_search: Optional[bool] = Field(False, description="Enable web search for this request (Ollama only)")
 
 class ChatResponse(BaseModel):
     """Schema for a chat response."""

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -1,0 +1,290 @@
+"""
+Web Search Service using Exa API for enhanced AI-powered search.
+"""
+
+import logging
+from typing import List, Dict, Any, Optional
+from dataclasses import dataclass, field
+import asyncio
+import json
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class SearchResult:
+    """Represents a single search result."""
+    title: str
+    url: str
+    snippet: str
+    score: Optional[float] = None
+    published_date: Optional[str] = None
+    author: Optional[str] = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "title": self.title,
+            "url": self.url,
+            "snippet": self.snippet,
+            "score": self.score,
+            "published_date": self.published_date,
+            "author": self.author
+        }
+
+@dataclass
+class SearchService:
+    """Service for web search functionality using Exa API."""
+    
+    api_key: Optional[str] = field(default_factory=lambda: settings.EXA_API_KEY)
+    enabled: bool = field(default_factory=lambda: settings.EXA_SEARCH_ENABLED)
+    
+    def __post_init__(self):
+        """Initialize the search client."""
+        self.client = None
+        if self.enabled and self.api_key:
+            try:
+                from exa_py import Exa
+                self.client = Exa(api_key=self.api_key)
+                logger.info("Exa search client initialized successfully")
+            except ImportError:
+                logger.error("exa_py package not installed. Run: pip install exa_py")
+                self.enabled = False
+            except Exception as e:
+                logger.error(f"Failed to initialize Exa client: {str(e)}")
+                self.enabled = False
+    
+    async def search(
+        self, 
+        query: str, 
+        num_results: int = 5,
+        use_autoprompt: bool = True,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+        category: Optional[str] = None,
+        include_text: bool = True
+    ) -> List[SearchResult]:
+        """
+        Perform a web search using Exa API.
+        
+        Args:
+            query: Search query
+            num_results: Number of results to return
+            use_autoprompt: Whether to use Exa's autoprompt feature
+            include_domains: List of domains to include
+            exclude_domains: List of domains to exclude
+            start_published_date: Filter by start date (YYYY-MM-DD)
+            end_published_date: Filter by end date (YYYY-MM-DD)
+            category: Category filter (e.g., "news", "papers", "company")
+            include_text: Whether to include text content
+            
+        Returns:
+            List of SearchResult objects
+        """
+        if not self.enabled or not self.client:
+            logger.warning("Search service is not enabled or initialized")
+            return []
+        
+        try:
+            # Build search parameters
+            search_params = {
+                "num_results": num_results,
+                "use_autoprompt": use_autoprompt,
+            }
+            
+            if include_domains:
+                search_params["include_domains"] = include_domains
+            if exclude_domains:
+                search_params["exclude_domains"] = exclude_domains
+            if start_published_date:
+                search_params["start_published_date"] = start_published_date
+            if end_published_date:
+                search_params["end_published_date"] = end_published_date
+            if category:
+                search_params["category"] = category
+                
+            # Perform search with optional content retrieval
+            if include_text:
+                # Use search_and_contents for efficiency
+                response = await asyncio.to_thread(
+                    self.client.search_and_contents,
+                    query,
+                    text={"max_characters": 500},  # Limit text for snippets
+                    **search_params
+                )
+            else:
+                response = await asyncio.to_thread(
+                    self.client.search,
+                    query,
+                    **search_params
+                )
+            
+            # Parse results
+            results = []
+            for result in response.results:
+                snippet = ""
+                if hasattr(result, 'text'):
+                    snippet = result.text[:500] if result.text else ""
+                elif hasattr(result, 'snippet'):
+                    snippet = result.snippet
+                    
+                results.append(SearchResult(
+                    title=getattr(result, 'title', 'No title'),
+                    url=result.url,
+                    snippet=snippet,
+                    score=getattr(result, 'score', None),
+                    published_date=getattr(result, 'published_date', None),
+                    author=getattr(result, 'author', None)
+                ))
+            
+            logger.info(f"Search completed: {len(results)} results for query: {query}")
+            return results
+            
+        except Exception as e:
+            logger.error(f"Search failed: {str(e)}")
+            return []
+    
+    async def find_similar(self, url: str, num_results: int = 5) -> List[SearchResult]:
+        """
+        Find similar pages to a given URL.
+        
+        Args:
+            url: URL to find similar pages for
+            num_results: Number of results to return
+            
+        Returns:
+            List of SearchResult objects
+        """
+        if not self.enabled or not self.client:
+            logger.warning("Search service is not enabled or initialized")
+            return []
+        
+        try:
+            response = await asyncio.to_thread(
+                self.client.find_similar,
+                url,
+                num_results=num_results
+            )
+            
+            results = []
+            for result in response.results:
+                results.append(SearchResult(
+                    title=getattr(result, 'title', 'No title'),
+                    url=result.url,
+                    snippet=getattr(result, 'text', '')[:500] if hasattr(result, 'text') else '',
+                    score=getattr(result, 'score', None),
+                    published_date=getattr(result, 'published_date', None),
+                    author=getattr(result, 'author', None)
+                ))
+            
+            logger.info(f"Found {len(results)} similar pages for: {url}")
+            return results
+            
+        except Exception as e:
+            logger.error(f"Find similar failed: {str(e)}")
+            return []
+    
+    async def get_contents(self, urls: List[str]) -> Dict[str, str]:
+        """
+        Get full text content for a list of URLs.
+        
+        Args:
+            urls: List of URLs to get content for
+            
+        Returns:
+            Dictionary mapping URLs to their text content
+        """
+        if not self.enabled or not self.client:
+            logger.warning("Search service is not enabled or initialized")
+            return {}
+        
+        try:
+            response = await asyncio.to_thread(
+                self.client.get_contents,
+                urls
+            )
+            
+            contents = {}
+            for result in response.results:
+                if hasattr(result, 'text'):
+                    contents[result.url] = result.text
+            
+            logger.info(f"Retrieved content for {len(contents)} URLs")
+            return contents
+            
+        except Exception as e:
+            logger.error(f"Get contents failed: {str(e)}")
+            return {}
+    
+    def format_for_llm(self, results: List[SearchResult], max_results: int = 3) -> str:
+        """
+        Format search results for LLM consumption.
+        
+        Args:
+            results: List of search results
+            max_results: Maximum number of results to include
+            
+        Returns:
+            Formatted string for LLM context
+        """
+        if not results:
+            return "No search results found."
+        
+        formatted = "Web Search Results:\n\n"
+        for i, result in enumerate(results[:max_results], 1):
+            formatted += f"{i}. **{result.title}**\n"
+            formatted += f"   URL: {result.url}\n"
+            if result.snippet:
+                formatted += f"   Summary: {result.snippet}\n"
+            if result.published_date:
+                formatted += f"   Published: {result.published_date}\n"
+            formatted += "\n"
+        
+        return formatted
+
+# Create tool definition for Ollama function calling
+def get_search_tool_definition() -> Dict[str, Any]:
+    """Get the tool definition for Ollama function calling."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web for current information using Exa's AI-powered search",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query"
+                    },
+                    "num_results": {
+                        "type": "integer",
+                        "description": "Number of results to return (default: 5)",
+                        "default": 5
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "Category filter: news, papers, company, etc.",
+                        "enum": ["news", "papers", "company", "tweet", "github", "personal_site"]
+                    },
+                    "include_domains": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of domains to include in search"
+                    },
+                    "exclude_domains": {
+                        "type": "array", 
+                        "items": {"type": "string"},
+                        "description": "List of domains to exclude from search"
+                    }
+                },
+                "required": ["query"]
+            }
+        }
+    }
+
+# Global instance
+search_service = SearchService()

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const temperatureRange = document.getElementById('temperatureRange');
     const temperatureValue = document.getElementById('temperatureValue');
     const maxTokensInput = document.getElementById('maxTokensInput');
+    const enableSearchCheck = document.getElementById('enableSearchCheck');
+    const searchStatus = document.getElementById('searchStatus');
     
     // Chat state
     let chatHistory = [];
@@ -20,6 +22,41 @@ document.addEventListener('DOMContentLoaded', function() {
     // Update temperature value display
     temperatureRange.addEventListener('input', function() {
         temperatureValue.textContent = this.value;
+    });
+    
+    // Handle model selection changes
+    modelSelect.addEventListener('change', function() {
+        const selectedModel = this.value;
+        // Enable web search for Ollama models that support it
+        if (selectedModel && selectedModel.startsWith('ollama:')) {
+            const modelName = selectedModel.replace('ollama:', '');
+            if (modelName.includes('gpt-oss') || modelName.includes('llama')) {
+                enableSearchCheck.disabled = false;
+                searchStatus.textContent = enableSearchCheck.checked ? 'Ready' : 'Available';
+                searchStatus.className = 'badge bg-success ms-1';
+            } else {
+                enableSearchCheck.disabled = true;
+                enableSearchCheck.checked = false;
+                searchStatus.textContent = 'Not Supported';
+                searchStatus.className = 'badge bg-warning ms-1';
+            }
+        } else {
+            enableSearchCheck.disabled = true;
+            enableSearchCheck.checked = false;
+            searchStatus.textContent = 'Off';
+            searchStatus.className = 'badge bg-secondary ms-1';
+        }
+    });
+    
+    // Handle search toggle
+    enableSearchCheck.addEventListener('change', function() {
+        if (this.checked) {
+            searchStatus.textContent = 'Enabled';
+            searchStatus.className = 'badge bg-primary ms-1';
+        } else {
+            searchStatus.textContent = 'Available';
+            searchStatus.className = 'badge bg-success ms-1';
+        }
     });
     
     // Auto-resize textarea
@@ -59,6 +96,14 @@ document.addEventListener('DOMContentLoaded', function() {
         const temperature = parseFloat(temperatureRange.value);
         const maxTokens = maxTokensInput.value ? parseInt(maxTokensInput.value) : null;
         
+        // Determine provider and actual model name
+        let provider = null;
+        let actualModel = model;
+        if (model && model.startsWith('ollama:')) {
+            provider = 'ollama';
+            actualModel = model.replace('ollama:', '');
+        }
+        
         // Add to chat history
         chatHistory.push({
             role: 'user',
@@ -69,11 +114,12 @@ document.addEventListener('DOMContentLoaded', function() {
         // Prepare request
         const requestBody = {
             messages: chatHistory.map(msg => ({role: msg.role, content: msg.content})),
-            model: model || null,
+            model: actualModel || null,
+            provider: provider,
             temperature: temperature,
             max_tokens: maxTokens,
             stream: true,
-            provider: provider  // Add provider if Ollama
+            enable_search: enableSearchCheck.checked
         };
 
         // Send request to API with streaming response

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -148,7 +148,7 @@
         <div class="settings-panel">
             <div class="settings-title">Chat Settings</div>
             <div class="row">
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <label for="modelSelect" class="form-label">Model</label>
                     <select id="modelSelect" class="form-select">
                         <optgroup label="Azure OpenAI (Cloud)">
@@ -162,16 +162,26 @@
                             <option value="ollama:mixtral:8x7b">Mixtral 8x7B 🏠</option>
                             <option value="ollama:deepseek-coder:6.7b">DeepSeek Coder 🏠</option>
                             <option value="ollama:llama3.2:3b">Llama 3.2 3B (Fast) 🏠</option>
+                            <option value="ollama:llama3.2:latest">Llama 3.2 🏠</option>
+                            <option value="ollama:mistral:latest">Mistral 🏠</option>
                         </optgroup>
                     </select>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <label for="temperatureRange" class="form-label">Temperature: <span id="temperatureValue">0.7</span></label>
                     <input type="range" class="form-range" id="temperatureRange" min="0" max="2" step="0.1" value="0.7">
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <label for="maxTokensInput" class="form-label">Max Tokens</label>
                     <input type="number" class="form-control" id="maxTokensInput" placeholder="Default">
+                </div>
+                <div class="col-md-3">
+                    <div class="form-check mt-4">
+                        <input class="form-check-input" type="checkbox" id="enableSearchCheck" disabled>
+                        <label class="form-check-label" for="enableSearchCheck">
+                            🔍 Web Search <span id="searchStatus" class="badge bg-secondary ms-1">Off</span>
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/docs/EXA_SEARCH_SETUP.md
+++ b/docs/EXA_SEARCH_SETUP.md
@@ -1,0 +1,234 @@
+# Exa Web Search Integration
+
+This document describes the Exa web search integration for Ollama models with native tool calling support.
+
+## Overview
+
+The application now supports AI-powered web search using Exa's neural search API, which is specifically designed for AI applications. When enabled, compatible models can autonomously decide when to search the web for current information.
+
+## Prerequisites
+
+1. **Exa API Key**: Sign up at [exa.ai](https://exa.ai) to get your API key
+   - Free tier includes $10 credits (~1000 searches)
+   - Dashboard: [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys)
+
+2. **Compatible Models**: Web search is supported for models with native function calling:
+   - GPT-OSS models (20B, 120B)
+   - Llama 3.1 (70B)
+   - Llama 3.2
+
+## Configuration
+
+### 1. Install Dependencies
+
+```bash
+pip install exa-py ollama
+```
+
+### 2. Environment Variables
+
+Add to your `.env` file:
+
+```env
+# Exa Search Configuration
+EXA_API_KEY=your_exa_api_key_here
+EXA_SEARCH_ENABLED=true
+
+# Ollama Configuration (if not using default)
+OLLAMA_BASE_URL=http://localhost:11434
+```
+
+### 3. Enable Search in UI
+
+1. Select an Ollama model that supports tool calling
+2. The web search checkbox will become available
+3. Check "🔍 Web Search" to enable for the conversation
+
+## How It Works
+
+### Architecture
+
+1. **Native Tool Calling**: GPT-OSS and compatible models support function calling natively
+2. **Automatic Invocation**: The model decides when to search based on the conversation context
+3. **Semantic Search**: Exa uses embeddings for meaning-based search, not just keywords
+4. **Result Integration**: Search results are automatically incorporated into the model's response
+
+### Search Flow
+
+```mermaid
+graph LR
+    A[User Query] --> B[Ollama Model]
+    B --> C{Needs Search?}
+    C -->|Yes| D[Call Exa API]
+    D --> E[Get Results]
+    E --> F[Add to Context]
+    F --> B
+    C -->|No| G[Generate Response]
+    B --> G
+```
+
+## Usage Examples
+
+### Basic Search
+
+When web search is enabled, the model will automatically search when needed:
+
+```
+User: "What are the latest developments in quantum computing in 2025?"
+Model: [Searches web automatically] Based on recent developments...
+```
+
+### Search Categories
+
+The integration supports category filters:
+- `news` - Recent news articles
+- `papers` - Academic papers
+- `company` - Company information
+- `tweet` - Twitter/X posts
+- `github` - GitHub repositories
+- `personal_site` - Personal websites
+
+### Domain Filtering
+
+You can configure domain inclusion/exclusion in the search service:
+
+```python
+# In search_service.py
+search_results = await search_service.search(
+    query="AI safety",
+    include_domains=["arxiv.org", "openai.com"],
+    exclude_domains=["reddit.com"]
+)
+```
+
+## API Reference
+
+### Search Service Methods
+
+#### `search(query, **kwargs)`
+Perform a web search with various filters.
+
+**Parameters:**
+- `query` (str): Search query
+- `num_results` (int): Number of results (default: 5)
+- `use_autoprompt` (bool): Use Exa's autoprompt feature (default: True)
+- `category` (str): Filter by category
+- `include_domains` (List[str]): Domains to include
+- `exclude_domains` (List[str]): Domains to exclude
+- `start_published_date` (str): Start date filter (YYYY-MM-DD)
+- `end_published_date` (str): End date filter (YYYY-MM-DD)
+
+#### `find_similar(url, num_results=5)`
+Find pages similar to a given URL.
+
+#### `get_contents(urls)`
+Retrieve full text content for URLs.
+
+## Tool Definition
+
+The search tool is defined for Ollama's function calling:
+
+```python
+{
+    "type": "function",
+    "function": {
+        "name": "web_search",
+        "description": "Search the web for current information",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "num_results": {"type": "integer", "default": 5},
+                "category": {"type": "string", "enum": ["news", "papers", ...]},
+                ...
+            },
+            "required": ["query"]
+        }
+    }
+}
+```
+
+## Monitoring & Debugging
+
+### Check Service Status
+
+```python
+from app.services.search_service import search_service
+
+# Check if search is enabled
+print(f"Search enabled: {search_service.enabled}")
+print(f"API key configured: {bool(search_service.api_key)}")
+```
+
+### View Logs
+
+```bash
+# Set log level to DEBUG for detailed information
+LOG_LEVEL=DEBUG python main.py
+```
+
+### Test Search Directly
+
+```python
+import asyncio
+from app.services.search_service import search_service
+
+async def test_search():
+    results = await search_service.search("latest AI news", num_results=3)
+    for result in results:
+        print(f"- {result.title}: {result.url}")
+
+asyncio.run(test_search())
+```
+
+## Limitations
+
+1. **API Credits**: Free tier is limited to $10 credits
+2. **Rate Limits**: Respect Exa's rate limits (varies by plan)
+3. **Model Support**: Only works with models that support function calling
+4. **Context Length**: Search results add to context, consider token limits
+
+## Troubleshooting
+
+### Search Not Available
+
+1. Check model compatibility (must support function calling)
+2. Verify EXA_API_KEY is set correctly
+3. Ensure EXA_SEARCH_ENABLED=true
+4. Check Ollama is running and accessible
+
+### No Search Results
+
+1. Verify API key is valid
+2. Check network connectivity
+3. Review search query formatting
+4. Check logs for specific errors
+
+### Integration Issues
+
+1. Ensure all dependencies are installed: `pip install exa-py ollama`
+2. Verify Ollama model supports tools: `ollama show model-name`
+3. Check Python version compatibility (3.8+)
+
+## Cost Optimization
+
+1. **Limit Results**: Use `num_results=3` for most queries
+2. **Cache Results**: Implement caching for repeated queries
+3. **Category Filters**: Use specific categories to reduce API calls
+4. **Domain Filters**: Limit to relevant domains when possible
+
+## Security Considerations
+
+1. **API Key**: Never commit EXA_API_KEY to version control
+2. **Input Validation**: The service validates all search parameters
+3. **Result Filtering**: Consider filtering sensitive content
+4. **Rate Limiting**: Implement user-level rate limits for production
+
+## Future Enhancements
+
+- [ ] Result caching with Redis
+- [ ] Custom relevance scoring
+- [ ] Multi-language search support
+- [ ] Search history tracking
+- [ ] Advanced filtering UI
+- [ ] Alternative search providers (DuckDuckGo, Tavily)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "langgraph>=0.5.1",
     "aiohttp>=3.9.0",
     "sqlalchemy>=2.0.41",
-    "ollama>=0.1.0",
+    "ollama>=0.1.7",
+    "exa-py>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/test_exa_search.py
+++ b/test_exa_search.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Test script for Exa web search integration with Ollama models.
+"""
+
+import asyncio
+import os
+import sys
+from dotenv import load_dotenv
+
+# Add the project directory to the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Load environment variables
+load_dotenv()
+
+async def test_exa_search():
+    """Test the Exa search service directly."""
+    print("\n" + "="*50)
+    print("Testing Exa Search Service")
+    print("="*50)
+    
+    from app.services.search_service import search_service
+    
+    # Check configuration
+    print(f"\n1. Configuration Check:")
+    print(f"   - Search Enabled: {search_service.enabled}")
+    print(f"   - API Key Set: {bool(search_service.api_key)}")
+    
+    if not search_service.enabled:
+        print("\n⚠️  Search service is not enabled!")
+        print("   Please set EXA_API_KEY and EXA_SEARCH_ENABLED=true in your .env file")
+        return False
+    
+    # Test basic search
+    print(f"\n2. Testing Basic Search:")
+    query = "latest developments in AI safety 2025"
+    print(f"   Query: '{query}'")
+    
+    try:
+        results = await search_service.search(query, num_results=3)
+        print(f"   Found {len(results)} results:")
+        for i, result in enumerate(results, 1):
+            print(f"   {i}. {result.title[:60]}...")
+            print(f"      URL: {result.url}")
+            if result.snippet:
+                print(f"      Snippet: {result.snippet[:100]}...")
+        print("   ✅ Basic search successful!")
+    except Exception as e:
+        print(f"   ❌ Search failed: {str(e)}")
+        return False
+    
+    # Test category search
+    print(f"\n3. Testing Category Search (news):")
+    try:
+        results = await search_service.search(
+            "OpenAI GPT", 
+            num_results=2,
+            category="news"
+        )
+        print(f"   Found {len(results)} news results")
+        print("   ✅ Category search successful!")
+    except Exception as e:
+        print(f"   ❌ Category search failed: {str(e)}")
+    
+    # Test formatting for LLM
+    print(f"\n4. Testing LLM Formatting:")
+    if results:
+        formatted = search_service.format_for_llm(results, max_results=2)
+        print("   Formatted output:")
+        print("   " + formatted.replace("\n", "\n   ")[:300] + "...")
+        print("   ✅ Formatting successful!")
+    
+    return True
+
+async def test_ollama_with_search():
+    """Test Ollama integration with web search."""
+    print("\n" + "="*50)
+    print("Testing Ollama Integration with Web Search")
+    print("="*50)
+    
+    from app.schemas.chat import ChatRequest, Message
+    from app.services.llm_service import LLMService
+    from app.core.config import settings
+    
+    # Check if Ollama is available
+    try:
+        import ollama
+        client = ollama.Client()
+        models = client.list()
+        print(f"\n1. Ollama Check:")
+        print(f"   - Ollama is running")
+        print(f"   - Available models: {len(models.get('models', []))}")
+        
+        # Find a compatible model
+        compatible_model = None
+        for model in models.get('models', []):
+            name = model.get('name', '')
+            if 'gpt-oss' in name.lower() or 'llama' in name.lower():
+                compatible_model = name
+                break
+        
+        if not compatible_model:
+            print("   ⚠️  No compatible models found (need GPT-OSS or Llama)")
+            print("   Run: ollama pull gpt-oss:20b")
+            return False
+            
+        print(f"   - Using model: {compatible_model}")
+        
+    except Exception as e:
+        print(f"\n⚠️  Ollama is not running or not installed")
+        print(f"   Error: {str(e)}")
+        print("   Please start Ollama and pull a compatible model")
+        return False
+    
+    # Test with search enabled
+    print(f"\n2. Testing Chat with Web Search:")
+    
+    # Create a test request that should trigger search
+    request = ChatRequest(
+        messages=[
+            Message(role="user", content="What are the latest features in GPT-OSS models announced by OpenAI?")
+        ],
+        model=compatible_model.split(':')[0],  # Remove tag
+        provider="ollama",
+        temperature=0.7,
+        enable_search=True,
+        stream=False
+    )
+    
+    # Create service instance
+    service = LLMService(provider="ollama", model=compatible_model)
+    
+    print(f"   Sending query to {compatible_model}...")
+    print(f"   Web search: Enabled")
+    
+    try:
+        response = await service.generate_response(request)
+        print(f"\n   Response received:")
+        print(f"   {response.message.content[:500]}...")
+        
+        if response.usage:
+            print(f"\n   Token usage:")
+            print(f"   - Prompt: {response.usage.get('prompt_tokens', 'N/A')}")
+            print(f"   - Completion: {response.usage.get('completion_tokens', 'N/A')}")
+        
+        print("\n   ✅ Ollama with web search successful!")
+        
+    except Exception as e:
+        print(f"\n   ❌ Request failed: {str(e)}")
+        return False
+    
+    return True
+
+async def main():
+    """Run all tests."""
+    print("\n🚀 Starting Exa Search Integration Tests\n")
+    
+    # Test Exa search service
+    exa_success = await test_exa_search()
+    
+    # Only test Ollama if Exa is working
+    if exa_success:
+        ollama_success = await test_ollama_with_search()
+    else:
+        ollama_success = False
+    
+    # Summary
+    print("\n" + "="*50)
+    print("Test Summary")
+    print("="*50)
+    print(f"✅ Exa Search Service: {'PASSED' if exa_success else 'FAILED'}")
+    print(f"{'✅' if ollama_success else '❌'} Ollama Integration: {'PASSED' if ollama_success else 'FAILED/SKIPPED'}")
+    
+    if exa_success and ollama_success:
+        print("\n🎉 All tests passed! Web search is ready to use.")
+        print("\nTo use in the chat app:")
+        print("1. Start the app: python main.py")
+        print("2. Select an Ollama model (GPT-OSS or Llama)")
+        print("3. Enable web search with the checkbox")
+        print("4. Ask questions that need current information")
+    elif exa_success:
+        print("\n⚠️  Exa search works but Ollama integration needs setup.")
+        print("Please ensure Ollama is running with a compatible model.")
+    else:
+        print("\n❌ Tests failed. Please check your configuration.")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Integrated Exa AI-powered web search for Ollama models
- Added search toggle in UI that enables/disables web search
- Implemented tool calling functionality for compatible Ollama models (GPT-OSS, Llama)

## Features
- Web search capability for current information retrieval
- Function calling support for Ollama models
- Graceful fallback when search is unavailable
- UI toggle to enable/disable search per request

## Configuration
Add these environment variables to enable web search:
```bash
EXA_API_KEY=your_exa_api_key
EXA_SEARCH_ENABLED=true
```

## Implementation Details
- Added `search_service.py` for Exa API integration
- Modified Ollama handler to support tool calling
- Added UI controls for search toggle
- Maintains compatibility with connection pooling optimizations

## Test Plan
- [ ] Test with Ollama models that support function calling
- [ ] Verify search toggle works correctly
- [ ] Confirm graceful fallback when Exa is not configured
- [ ] Test search results are properly injected into context