### PR TITLE
fix: Update tests to work with connection pooling

### DIFF
--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -106,12 +106,13 @@ class TestLLMService:
             mock_settings.API_REQUEST_TIMEOUT = 60
             mock_settings.LLM_API_KEY = "test-key-1234567890"
             mock_settings.LLM_API_ENDPOINT = "https://api.openai.com/v1"
+            mock_settings.OLLAMA_BASE_URL = "http://localhost:11434"
             
-            with patch('openai.AsyncOpenAI') as mock_openai:
-                service = LLMService()
-                assert service.provider == "openai"
-                assert service.model == "gpt-4"
-                mock_openai.assert_called_once()
+            service = LLMService()
+            assert service.provider == "openai"
+            assert service.model == "gpt-4"
+            assert service.timeout == 60
+            # No longer test for client creation as it's done lazily via ClientManager
 
     def test_format_messages(self):
         """Test message formatting."""
@@ -121,20 +122,20 @@ class TestLLMService:
             mock_settings.API_REQUEST_TIMEOUT = 60
             mock_settings.LLM_API_KEY = "test-key-1234567890"
             mock_settings.LLM_API_ENDPOINT = "https://api.openai.com/v1"
+            mock_settings.OLLAMA_BASE_URL = "http://localhost:11434"
             
-            with patch('openai.AsyncOpenAI'):
-                service = LLMService()
-                messages = [
-                    Message(role="user", content="Hello"),
-                    Message(role="assistant", content="Hi there!"),
-                ]
-                formatted = service.format_messages(messages)
-                
-                expected = [
-                    {"role": "user", "content": "Hello"},
-                    {"role": "assistant", "content": "Hi there!"},
-                ]
-                assert formatted == expected
+            service = LLMService()
+            messages = [
+                Message(role="user", content="Hello"),
+                Message(role="assistant", content="Hi there!"),
+            ]
+            formatted = service.format_messages(messages)
+            
+            expected = [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ]
+            assert formatted == expected
 
     def test_format_messages_with_invalid_role(self):
         """Test message formatting with invalid role."""


### PR DESCRIPTION
## Summary
- Fixed failing CI tests after connection pooling implementation
- Updated test mocks to reflect new lazy client initialization pattern

## Changes
- Removed direct `AsyncOpenAI` client creation assertions from tests
- Added `OLLAMA_BASE_URL` to test configurations
- Fixed indentation issues in test methods
- Tests now properly handle ClientManager's lazy initialization

## Test Results
All 34 tests passing locally:
```
======================== 34 passed, 7 warnings in 0.79s ========================
```

## Context
The CI tests were failing because the LLMService now uses ClientManager for connection pooling, which creates clients lazily rather than during initialization. The tests were expecting the old behavior where clients were created immediately.

This PR updates the tests to match the new architecture while maintaining full test coverage.