### PR TITLE
Adjust settings validators for Pydantic v2

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,82 +1,91 @@
-from pydantic_settings import BaseSettings
-from pydantic import Field, validator
-from typing import Optional, List
-import os
+from typing import List, Optional
+
 from dotenv import load_dotenv
+from pydantic import Field, FieldValidationInfo, field_validator
+from pydantic_settings import BaseSettings
 
 # Load environment variables from .env file
 load_dotenv()
 
+
 class Settings(BaseSettings):
     """Application settings with proper validation."""
-    
+
     # API Configuration
     LLM_API_KEY: str = Field(default="", description="API key for LLM provider")
     LLM_API_ENDPOINT: str = Field(default="https://api.openai.com/v1", description="LLM API endpoint")
     LLM_MODEL: str = Field(default="gpt-4", description="Default LLM model")
     LLM_PROVIDER: str = Field(default="openai", description="LLM provider (openai, anthropic, gemini, ollama)")
-    
+
     # Ollama Configuration
     OLLAMA_BASE_URL: str = Field(default="http://localhost:11434", description="Ollama API base URL")
-    
+
     # Application Settings
     APP_ENV: str = Field(default="development", description="Application environment")
     DEBUG: bool = Field(default=True, description="Debug mode")
     LOG_LEVEL: str = Field(default="INFO", description="Logging level")
     PORT: int = Field(default=8000, description="Server port", ge=1, le=65535)
     HOST: str = Field(default="0.0.0.0", description="Server host")
-    
+
     # Security
-    SECRET_KEY: str = Field(default="development_secret_key_change_in_production_32chars", description="Secret key for security features")
+    SECRET_KEY: str = Field(
+        default="development_secret_key_change_in_production_32chars",
+        description="Secret key for security features",
+    )
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(default=30, description="Token expiration time", ge=1)
-    ALLOWED_ORIGINS: List[str] = Field(default=["http://localhost:3000", "http://localhost:8000"], description="Allowed CORS origins")
+    ALLOWED_ORIGINS: List[str] = Field(
+        default=["http://localhost:3000", "http://localhost:8000"],
+        description="Allowed CORS origins",
+    )
     API_REQUEST_TIMEOUT: int = Field(default=60, description="API request timeout in seconds", ge=1)
-    
+
     # Rate Limiting
     RATE_LIMIT_REQUESTS: int = Field(default=100, description="Rate limit requests per minute", ge=1)
     RATE_LIMIT_WINDOW: int = Field(default=60, description="Rate limit window in seconds", ge=1)
-    
+
     # Database Configuration
     DATABASE_URL: Optional[str] = Field(default=None, description="Database URL")
-    
+
     # Connection Pooling Configuration
     HTTP_MAX_CONNECTIONS: int = Field(default=100, description="Maximum HTTP connections in pool", ge=1, le=500)
     HTTP_MAX_KEEPALIVE: int = Field(default=20, description="Maximum keep-alive connections", ge=1, le=100)
     HTTP_KEEPALIVE_EXPIRY: int = Field(default=30, description="Keep-alive connection expiry in seconds", ge=5, le=300)
     HTTP_CONNECTION_TIMEOUT: int = Field(default=10, description="Connection timeout in seconds", ge=1, le=60)
-    
+
     # Exa Search Configuration
     EXA_API_KEY: Optional[str] = Field(default=None, description="Exa API key for web search")
     EXA_SEARCH_ENABLED: bool = Field(default=False, description="Enable Exa web search for Ollama models")
-    @validator('LLM_PROVIDER')
-    def validate_provider(cls, v):
-        allowed_providers = ['openai', 'anthropic', 'gemini', 'ollama']
+
+    @field_validator("LLM_PROVIDER")
+    def validate_provider(cls, v: str) -> str:
+        allowed_providers = ["openai", "anthropic", "gemini", "ollama"]
         if v.lower() not in allowed_providers:
-            raise ValueError(f'Provider must be one of: {allowed_providers}')
+            raise ValueError(f"Provider must be one of: {allowed_providers}")
         return v.lower()
-    
-    @validator('LOG_LEVEL')
-    def validate_log_level(cls, v):
-        allowed_levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+
+    @field_validator("LOG_LEVEL")
+    def validate_log_level(cls, v: str) -> str:
+        allowed_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         if v.upper() not in allowed_levels:
-            raise ValueError(f'Log level must be one of: {allowed_levels}')
+            raise ValueError(f"Log level must be one of: {allowed_levels}")
         return v.upper()
-    
-    @validator('LLM_API_KEY')
-    def validate_api_key(cls, v, values):
+
+    @field_validator("LLM_API_KEY")
+    def validate_api_key(cls, v: str, info: FieldValidationInfo) -> str:
         # Ollama doesn't require an API key
-        provider = values.get('LLM_PROVIDER', '').lower()
-        if provider == 'ollama':
-            return v.strip() if v else ""  # No API key needed for Ollama
+        provider = (info.data.get("LLM_PROVIDER") or "").lower()
+        value = v or ""
+        if provider == "ollama":
+            return value.strip()  # No API key needed for Ollama
         # Only validate if API key is provided (allow empty for development)
-        if v and len(v.strip()) < 10:
-            raise ValueError('LLM_API_KEY must be at least 10 characters long when provided')
-        return v.strip() if v else ""
-    
-    @validator('SECRET_KEY')
-    def validate_secret_key(cls, v):
+        if value and len(value.strip()) < 10:
+            raise ValueError("LLM_API_KEY must be at least 10 characters long when provided")
+        return value.strip()
+
+    @field_validator("SECRET_KEY")
+    def validate_secret_key(cls, v: str) -> str:
         if len(v.strip()) < 32:
-            raise ValueError('SECRET_KEY must be at least 32 characters long')
+            raise ValueError("SECRET_KEY must be at least 32 characters long")
         return v.strip()
 
     class Config:
@@ -84,5 +93,6 @@ class Settings(BaseSettings):
         case_sensitive = True
         validate_assignment = True
 
+
 # Create a global settings object
-settings = Settings() 
+settings = Settings()


### PR DESCRIPTION
## Summary
- replace deprecated validator usage in `Settings` with `field_validator` compatible with Pydantic v2
- keep existing validation behavior while modernizing imports and helper usage

## Testing
- python - <<'PY'
from app.core.config import Settings
Settings()
print("Settings instantiated successfully")
PY

------
https://chatgpt.com/codex/tasks/task_e_68f1eb8502a0832caeb44a690c03f860